### PR TITLE
Fix mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This endpoint must:
 1.  Generate PKCE code.
     - The code verifier should be saved in a secure **HTTP-only** cookie.
     - The code challenge is passed along
-2.  Encode and save `redirect_url` from react app to `state`.
+2.  Encode and save `redirect_url` from the client app to `state`.
 3.  Redirect browser to `/oauth2/authorize` with a `redirect_uri` to `/app/token-exchange`
 
 [Example implementation](https://github.com/FusionAuth/fusionauth-javascript-sdk-express/blob/main/routes/login.js)
@@ -68,7 +68,7 @@ This endpoint is similar to `/login`. It must:
 1.  Generate PKCE code.
     - The code verifier should be saved in a secure **HTTP-only** cookie.
     - The code challenge is passed along
-2.  Encode and save `redirect_url` from react app to `state`.
+2.  Encode and save `redirect_url` from the client app to `state`.
 3.  Redirect browser to `/oauth2/register` with a `redirect_uri` to `/app/callback`
 
 [Example implementation](https://github.com/FusionAuth/fusionauth-javascript-sdk-express/blob/main/routes/register.js)


### PR DESCRIPTION
Fixing 2 places where the copy referred to `react`. This, obviously a frontend-framework-agnostic example, so this is needed!