### PR TITLE
at_exp issue and `scope` issue fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ This endpoint must:
 3.  If you wish to support refresh tokens, repeat step 2 for the
     `app.rt` cookie.
 
-4.  Save the expiration time in a readable `app.at_exp` cookie. And save the `app.idt` id token in a readable cookie.
+4.  Save the expiration time in a readable `app.at_exp` cookie. This value should be represented as seconds since the epoch.
 
-5.  Redirect browser back to encoded url saved in `state`.
+5.  And save the `app.idt` id token in a readable cookie.
 
-6.  Call
+6.  Redirect browser back to encoded url saved in `state`.
+
+7.  Call
     [/oauth2/userinfo](https://fusionauth.io/docs/v1/tech/oauth/endpoints#userinfo)
     to retrieve the user info object and respond back to the client with
     this object.

--- a/config.js
+++ b/config.js
@@ -1,9 +1,9 @@
 module.exports = {
-	// FusionAuth info (copied from the FusionAuth admin panel)
-	clientID: 'e9fdb985-9173-4e01-9d73-ac2d60d1dc8e',
-	clientSecret: 'super-secret-secret-that-should-be-regenerated-for-production',
-	fusionAuthBaseUrl: 'http://localhost:9011',
+  // FusionAuth info (copied from the FusionAuth admin panel)
+  clientId: 'e9fdb985-9173-4e01-9d73-ac2d60d1dc8e',
+  clientSecret: 'super-secret-secret-that-should-be-regenerated-for-production',
+  fusionAuthBaseUrl: 'http://localhost:9011',
 
-	// port this server runs on
-	serverPort: 9000
+  // port this server runs on
+  serverPort: 9000
 };

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ app.use(session(
 // use routes
 app.use('/app/login', require('./routes/login.js'));
 app.use('/app/callback', require('./routes/callback.js'));
-app.use('/app/refresh/:clientID', require('./routes/refresh.js'));
+app.use('/app/refresh', require('./routes/refresh.js'));
 app.use('/app/logout', require('./routes/logout.js'));
 app.use('/app/register', require('./routes/register.js'));
 app.use('/app/me', require('./routes/me.js'));

--- a/routes/callback.js
+++ b/routes/callback.js
@@ -20,7 +20,7 @@ router.get('/', async (req, res) => {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
       body: getFormURLEncodedPayload({
-        'client_id': config.clientID,
+        'client_id': config.clientId,
         'client_secret': config.clientSecret,
         'code': code,
         'code_verifier': codeVerifier,
@@ -42,7 +42,7 @@ router.get('/', async (req, res) => {
     cookie.setSecure(res, 'app.rt', refresh_token);
 
     const expires_in_ms = expires_in * 1000;
-    cookie.setReadable(res, 'app.at_exp', Date.now() + expires_in_ms, expires_in_ms);
+    cookie.setReadable(res, 'app.at_exp', (Date.now() + expires_in_ms) / 1000);
     cookie.setReadable(res, 'codeVerifier', '', 0);
     cookie.setReadable(res, "app.idt", id_token);
 

--- a/routes/login.js
+++ b/routes/login.js
@@ -18,7 +18,7 @@ router.get('/', async (req, res) => {
   
   const queryParams = {
       client_id: req.query.client_id,
-      scope: req.query.scope,
+      scope: 'openid offline_access',
       response_type: 'code',
       redirect_uri: token_exchange_uri,
       code_challenge: code.code_challenge,

--- a/routes/refresh.js
+++ b/routes/refresh.js
@@ -18,7 +18,7 @@ router.post('/', async (req, res) => {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
       body: getFormURLEncodedPayload({
-        'client_id': config.clientID,
+        'client_id': config.clientId,
         'client_secret': config.clientSecret,
         'grant_type': 'refresh_token',
         'refresh_token': req.cookies['app.rt'],
@@ -36,7 +36,7 @@ router.post('/', async (req, res) => {
     cookie.setSecure(res, 'app.rt', refresh_token);
 
     const expires_in_ms = expires_in * 1000;
-    cookie.setReadable(res, 'app.at_exp', Date.now() + expires_in_ms, expires_in_ms);
+    cookie.setReadable(res, "app.at_exp", (Date.now() + expires_in_ms) / 1000);
     cookie.setReadable(res, "app.idt", id_token);
 
     res.sendStatus(204);

--- a/routes/register.js
+++ b/routes/register.js
@@ -20,7 +20,7 @@ router.get("/", async (req, res) => {
   const redirect_uri = `${req.protocol}://${req.get("host")}/app/callback`;
   const queryParams = {
     client_id: req.query.client_id,
-    scope: req.query.scope,
+    scope: 'openid offline_access',
     response_type: "code",
     redirect_uri: redirect_uri,
     code_challenge: code.code_challenge,


### PR DESCRIPTION
#8 The `at_exp` cookie implementation must be consistent with the FA hosted server for this to be compatible with the SDKs. The value is represented as seconds since epoch. Added an addendum to the README because this is not mentioned.

#9 The `scope` parameter should be default `openid offline_access` by default and not pulled from query params.