### PR TITLE
Register and Login endpoints should pass scope parameter to fusionauth

### DIFF
--- a/routes/login.js
+++ b/routes/login.js
@@ -18,7 +18,7 @@ router.get('/', async (req, res) => {
   
   const queryParams = {
       client_id: req.query.client_id,
-      scope: 'openid offline_access',
+      scope: req.query.scope ?? 'openid offline_access',
       response_type: 'code',
       redirect_uri: token_exchange_uri,
       code_challenge: code.code_challenge,

--- a/routes/register.js
+++ b/routes/register.js
@@ -20,7 +20,7 @@ router.get("/", async (req, res) => {
   const redirect_uri = `${req.protocol}://${req.get("host")}/app/callback`;
   const queryParams = {
     client_id: req.query.client_id,
-    scope: 'openid offline_access',
+    scope: req.query.scope ?? "openid offline_access",
     response_type: "code",
     redirect_uri: redirect_uri,
     code_challenge: code.code_challenge,


### PR DESCRIPTION
#13 
This is to keep up with `scope` changes in [FusionAuth v1.50](https://fusionauth.io/docs/release-notes/#version-1-50-0)